### PR TITLE
Fix: Address LOS Issues

### DIFF
--- a/internal/game/los.go
+++ b/internal/game/los.go
@@ -2,7 +2,7 @@ package game
 
 import (
 	"codeberg.org/anaseto/gruid"
-	"github.com/lecoqjacob/ai-go/roguelike-gruid-project/internal/utils"
+	"codeberg.org/anaseto/gruid/paths"
 )
 
 // Define the passable function once (reusing Map's IsOpaque)
@@ -17,16 +17,16 @@ func (g *Game) FOVSystem() {
 	for _, entity := range entities {
 		id, pos, fov := entity.ID, entity.Position, entity.FOV
 		fov.ClearVisible()
-		fovCalculator := fov.GetFOVCalculator()
-		visibleTiles := fovCalculator.SSCVisionMap(pos, fov.Range, g.passable, false) // Use asserted pos
-		visibleTiles = utils.DrawFilledCircle(visibleTiles, fov.Range, pos)           // Use asserted pos
 
-		// Update visibility and explored status for points in the circle
-		for _, p := range visibleTiles {
+		fovCalculator := fov.GetFOVCalculator()
+		for _, p := range fovCalculator.SSCVisionMap(pos, fov.Range, g.passable, false) {
+			if paths.DistanceManhattan(p, pos) > fov.Range {
+				continue
+			}
+
 			fov.SetVisible(p, g.dungeon.Width)
 
-			// If this is the player, also update the global explored map
-			if id == g.PlayerID {
+			if id == g.PlayerID && !g.dungeon.IsExplored(p) {
 				g.dungeon.SetExplored(p)
 			}
 		}

--- a/internal/game/spawner.go
+++ b/internal/game/spawner.go
@@ -23,7 +23,7 @@ func (g *Game) SpawnPlayer(playerStart gruid.Point, items map[string]components.
 		components.Renderable{Glyph: '@', Color: ui.ColorPlayer},
 		components.NewHealth(10),
 		components.NewTurnActor(100),
-		components.NewFOVComponent(4, g.dungeon.Width, g.dungeon.Height),
+		components.NewFOVComponent(10, g.dungeon.Width, g.dungeon.Height),
 		components.NewInventory(20),   // 20 slot inventory
 		components.NewEquipment(),     // Empty equipment slots
 		components.NewStats(),         // Starting stats

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
 
 # Build the game
 build:
-    go build -o ../roguelike ./cmd/roguelike
+    go build -o ./roguelike ./cmd/roguelike
 
 # Run the game
 run: build


### PR DESCRIPTION
This pull request introduces changes to improve the game's field-of-view (FOV) system, adjust the player's initial attributes, and update the build configuration. The most significant updates include replacing the utility function for FOV calculations with a new library, optimizing visibility checks, increasing the player's FOV range, and modifying the build path.

### FOV System Improvements:
* [`internal/game/los.go`](diffhunk://#diff-c82433285b2b552a20f88493315d479dee92fa4667a54ed040bec59c4285b1cdR20-R29): Replaced the `utils.DrawFilledCircle` function with `paths.DistanceManhattan` for more precise FOV calculations, ensuring tiles outside the FOV range are excluded.
* [`internal/game/los.go`](diffhunk://#diff-c82433285b2b552a20f88493315d479dee92fa4667a54ed040bec59c4285b1cdL5-R5): Updated the import statement to use the `gruid/paths` library for pathfinding and distance calculations, replacing the previous `utils` package.

### Player Attributes Adjustment:
* [`internal/game/spawner.go`](diffhunk://#diff-0a4ce116c6028177d57cdb5f3413afa04bc29154d2b7afbe7a7718e14d8b2054L26-R26): Increased the player's FOV range from 4 to 10, enhancing gameplay by allowing the player to see a larger area of the dungeon.

### Build Configuration Update:
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L10-R10): Changed the build output path from `../roguelike` to `./roguelike` for better consistency and easier access within the project directory.